### PR TITLE
rename getKey to getByKey

### DIFF
--- a/lib/cache-function-promise.js
+++ b/lib/cache-function-promise.js
@@ -2,7 +2,7 @@
 
 module.exports = (client) => {
   // promisify a few methods to make the code below simpler
-  const getKey = (key) => new Promise((resolve, reject) => {
+  const getByKey = (key) => new Promise((resolve, reject) => {
     return client.get(key, (err, result) => err ? reject(err) : resolve(result))
   })
 
@@ -28,7 +28,7 @@ module.exports = (client) => {
     // .apply's are needed to support < node-6
     const key = keyProvider.apply(null, args)
 
-    return getKey(key)
+    return getByKey(key)
       .then((cacheResult) => {
         if (cacheResult) {
           return cacheResult.item


### PR DESCRIPTION
CS is easy except for two things: cache invalidation and naming... Unfortunately, this repo does both.